### PR TITLE
add: VPC関連のモジュールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,8 @@ pantri-iac/
 │       └── versions.tf       # バージョン制約
 ├── modules/                   # 共通モジュール
 │   ├── network/               # ネットワーク関連
-│   │   ├── vpc/               # VPC、サブネット、ルーティング
-│   │   ├── load-balancer/     # ALB、NLB
-│   │   └── security-groups/   # セキュリティグループ
+│   │   ├── vpc/               # VPC、サブネット、ルーティング、セキュリティグループ
+│   │   └── load-balancer/     # ALB、NLB
 │   ├── compute/               # 計算リソース関連
 │   │   ├── ecs/               # ECSクラスター、サービス、タスク
 │   │   ├── lambda/            # Lambda関数
@@ -68,9 +67,8 @@ pantri-iac/
 ## アーキテクチャコンポーネント
 
 ### ネットワーク層 (network/)
-- **VPC**: カスタムVPC、マルチAZサブネット、ルーティング
+- **VPC**: カスタムVPC、マルチAZサブネット、ルーティング、セキュリティグループ
 - **Load Balancer**: ALB/NLBによる負荷分散
-- **Security Groups**: きめ細かいネットワークアクセス制御
 
 ### 計算リソース層 (compute/)
 - **ECS**: Fargateタスクによるコンテナオーケストレーション

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ pantri-iac/
 │       └── versions.tf       # バージョン制約
 ├── modules/                   # 共通モジュール
 │   ├── network/               # ネットワーク関連
-│   │   ├── vpc/               # VPC、サブネット、ルーティング
-│   │   ├── load-balancer/     # ALB、NLB
-│   │   └── security-groups/   # セキュリティグループ
+│   │   ├── vpc/               # VPC、サブネット、ルーティング、セキュリティグループ
+│   │   └── load-balancer/     # ALB、NLB
 │   ├── compute/               # 計算リソース関連
 │   │   ├── ecs/               # ECSクラスター、サービス、タスク
 │   │   ├── lambda/            # Lambda関数

--- a/modules/network/vpc/endpoints.tf
+++ b/modules/network/vpc/endpoints.tf
@@ -1,0 +1,62 @@
+# VPC Endpoint for S3 (always enabled - free Gateway endpoint)
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = aws_vpc.main.id
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
+  route_table_ids = concat(
+    [aws_route_table.public.id],
+    values(aws_route_table.private)[*].id
+  )
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-s3-endpoint"
+  })
+}
+
+# VPC Endpoint for ECR API (for ECS)
+resource "aws_vpc_endpoint" "ecr_api" {
+  count = var.enable_vpc_endpoints ? 1 : 0
+
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = values(aws_subnet.private)[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
+  private_dns_enabled = true
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-ecr-api-endpoint"
+  })
+}
+
+# VPC Endpoint for ECR Docker
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  count = var.enable_vpc_endpoints ? 1 : 0
+
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = values(aws_subnet.private)[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
+  private_dns_enabled = true
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-ecr-dkr-endpoint"
+  })
+}
+
+# VPC Endpoint for CloudWatch Logs
+resource "aws_vpc_endpoint" "logs" {
+  count = var.enable_vpc_endpoints ? 1 : 0
+
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = values(aws_subnet.private)[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
+  private_dns_enabled = true
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-logs-endpoint"
+  })
+}

--- a/modules/network/vpc/flow-logs.tf
+++ b/modules/network/vpc/flow-logs.tf
@@ -64,8 +64,11 @@ resource "aws_iam_role_policy" "flow_log" {
           "logs:DescribeLogGroups",
           "logs:DescribeLogStreams"
         ]
-        Effect   = "Allow"
-        Resource = "*"
+        Effect = "Allow"
+        Resource = [
+          aws_cloudwatch_log_group.vpc_flow_log[0].arn,
+          "${aws_cloudwatch_log_group.vpc_flow_log[0].arn}:*"
+        ]
       }
     ]
   })

--- a/modules/network/vpc/flow-logs.tf
+++ b/modules/network/vpc/flow-logs.tf
@@ -1,0 +1,72 @@
+# VPC Flow Logs (for monitoring network traffic)
+resource "aws_flow_log" "vpc_flow_log" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  iam_role_arn    = aws_iam_role.flow_log[0].arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow_log[0].arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-vpc-flow-log"
+  })
+}
+
+# CloudWatch Log Group for VPC Flow Logs
+resource "aws_cloudwatch_log_group" "vpc_flow_log" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name              = "/aws/vpc/flow-logs/${var.environment}-${var.app_name}"
+  retention_in_days = var.flow_log_retention_days
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-vpc-flow-logs"
+  })
+}
+
+# IAM Role for VPC Flow Logs
+resource "aws_iam_role" "flow_log" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.environment}-${var.app_name}-vpc-flow-log-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "vpc-flow-logs.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# IAM Policy for VPC Flow Logs
+resource "aws_iam_role_policy" "flow_log" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.environment}-${var.app_name}-vpc-flow-log-policy"
+  role = aws_iam_role.flow_log[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/modules/network/vpc/gateways.tf
+++ b/modules/network/vpc/gateways.tf
@@ -1,0 +1,36 @@
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-igw"
+  })
+}
+
+# Elastic IPs for NAT Gateways
+resource "aws_eip" "nat" {
+  for_each = var.availability_zones_and_public_subnet_cidrs
+
+  domain     = "vpc"
+  depends_on = [aws_internet_gateway.main]
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-nat-eip-${each.key}"
+    AZ   = each.key
+  })
+}
+
+# NAT Gateways
+resource "aws_nat_gateway" "main" {
+  for_each = var.availability_zones_and_public_subnet_cidrs
+
+  allocation_id = aws_eip.nat[each.key].id
+  subnet_id     = aws_subnet.public[each.key].id
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-nat-gw-${each.key}"
+    AZ   = each.key
+  })
+
+  depends_on = [aws_internet_gateway.main]
+}

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -1,0 +1,13 @@
+# Data source for current AWS region
+data "aws_region" "current" {}
+
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-vpc"
+  })
+}

--- a/modules/network/vpc/outputs.tf
+++ b/modules/network/vpc/outputs.tf
@@ -143,7 +143,7 @@ output "vpc_flow_log_cloudwatch_log_group_name" {
 # VPC Endpoints
 output "vpc_endpoint_s3_id" {
   description = "The ID of VPC endpoint for S3"
-  value       = var.enable_vpc_endpoints ? aws_vpc_endpoint.s3[0].id : null
+  value       = var.enable_vpc_endpoints ? aws_vpc_endpoint.s3.id : null
 }
 
 output "vpc_endpoint_ecr_api_id" {

--- a/modules/network/vpc/outputs.tf
+++ b/modules/network/vpc/outputs.tf
@@ -1,0 +1,168 @@
+# VPC
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "vpc_arn" {
+  description = "The ARN of the VPC"
+  value       = aws_vpc.main.arn
+}
+
+output "vpc_cidr" {
+  description = "The CIDR block of the VPC"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "vpc_instance_tenancy" {
+  description = "Tenancy of instances spin up within VPC"
+  value       = aws_vpc.main.instance_tenancy
+}
+
+output "vpc_enable_dns_support" {
+  description = "Whether or not the VPC has DNS support"
+  value       = aws_vpc.main.enable_dns_support
+}
+
+output "vpc_enable_dns_hostnames" {
+  description = "Whether or not the VPC has DNS hostname support"
+  value       = aws_vpc.main.enable_dns_hostnames
+}
+
+output "vpc_main_route_table_id" {
+  description = "The ID of the main route table associated with this VPC"
+  value       = aws_vpc.main.main_route_table_id
+}
+
+output "vpc_default_network_acl_id" {
+  description = "The ID of the default network ACL"
+  value       = aws_vpc.main.default_network_acl_id
+}
+
+output "vpc_default_security_group_id" {
+  description = "The ID of the security group created by default on VPC creation"
+  value       = aws_vpc.main.default_security_group_id
+}
+
+output "vpc_default_route_table_id" {
+  description = "The ID of the default route table"
+  value       = aws_vpc.main.default_route_table_id
+}
+
+# Internet Gateway
+output "internet_gateway_id" {
+  description = "The ID of the Internet Gateway"
+  value       = aws_internet_gateway.main.id
+}
+
+output "internet_gateway_arn" {
+  description = "The ARN of the Internet Gateway"
+  value       = aws_internet_gateway.main.arn
+}
+
+# Public Subnets
+output "public_subnet_ids" {
+  description = "List of IDs of the public subnets"
+  value       = values(aws_subnet.public)[*].id
+}
+
+output "public_subnet_arns" {
+  description = "List of ARNs of the public subnets"
+  value       = values(aws_subnet.public)[*].arn
+}
+
+output "public_subnet_cidr_blocks" {
+  description = "List of CIDR blocks of the public subnets"
+  value       = values(aws_subnet.public)[*].cidr_block
+}
+
+output "public_subnet_availability_zones" {
+  description = "List of availability zones of the public subnets"
+  value       = values(aws_subnet.public)[*].availability_zone
+}
+
+# Private Subnets
+output "private_subnet_ids" {
+  description = "List of IDs of the private subnets"
+  value       = values(aws_subnet.private)[*].id
+}
+
+output "private_subnet_arns" {
+  description = "List of ARNs of the private subnets"
+  value       = values(aws_subnet.private)[*].arn
+}
+
+output "private_subnet_cidr_blocks" {
+  description = "List of CIDR blocks of the private subnets"
+  value       = values(aws_subnet.private)[*].cidr_block
+}
+
+output "private_subnet_availability_zones" {
+  description = "List of availability zones of the private subnets"
+  value       = values(aws_subnet.private)[*].availability_zone
+}
+
+# NAT Gateways
+output "nat_gateway_ids" {
+  description = "List of IDs of the NAT Gateways"
+  value       = values(aws_nat_gateway.main)[*].id
+}
+
+output "nat_gateway_public_ips" {
+  description = "List of public Elastic IPs associated with the NAT Gateways"
+  value       = values(aws_eip.nat)[*].public_ip
+}
+
+output "nat_gateway_allocation_ids" {
+  description = "List of allocation IDs of the Elastic IPs for the NAT Gateways"
+  value       = values(aws_eip.nat)[*].id
+}
+
+# Route Tables
+output "public_route_table_id" {
+  description = "ID of the public route table"
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_ids" {
+  description = "List of IDs of the private route tables"
+  value       = values(aws_route_table.private)[*].id
+}
+
+# VPC Flow Logs
+output "vpc_flow_log_id" {
+  description = "The ID of the VPC Flow Log"
+  value       = var.enable_flow_logs ? aws_flow_log.vpc_flow_log[0].id : null
+}
+
+output "vpc_flow_log_cloudwatch_log_group_name" {
+  description = "The name of the CloudWatch Log Group for VPC Flow Logs"
+  value       = var.enable_flow_logs ? aws_cloudwatch_log_group.vpc_flow_log[0].name : null
+}
+
+# VPC Endpoints
+output "vpc_endpoint_s3_id" {
+  description = "The ID of VPC endpoint for S3"
+  value       = var.enable_vpc_endpoints ? aws_vpc_endpoint.s3[0].id : null
+}
+
+output "vpc_endpoint_ecr_api_id" {
+  description = "The ID of VPC endpoint for ECR API"
+  value       = var.enable_vpc_endpoints ? aws_vpc_endpoint.ecr_api[0].id : null
+}
+
+output "vpc_endpoint_ecr_dkr_id" {
+  description = "The ID of VPC endpoint for ECR Docker"
+  value       = var.enable_vpc_endpoints ? aws_vpc_endpoint.ecr_dkr[0].id : null
+}
+
+output "vpc_endpoint_logs_id" {
+  description = "The ID of VPC endpoint for CloudWatch Logs"
+  value       = var.enable_vpc_endpoints ? aws_vpc_endpoint.logs[0].id : null
+}
+
+output "vpc_endpoints_security_group_id" {
+  description = "The ID of the security group for VPC endpoints"
+  value       = var.enable_vpc_endpoints ? aws_security_group.vpc_endpoints[0].id : null
+}
+

--- a/modules/network/vpc/routing.tf
+++ b/modules/network/vpc/routing.tf
@@ -1,0 +1,52 @@
+# Route Table for Public Subnets
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-public-rt"
+  })
+}
+
+# Route for Public Subnets to Internet Gateway
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.main.id
+}
+
+# Route Table Associations for Public Subnets
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+# Route Tables for Private Subnets
+resource "aws_route_table" "private" {
+  for_each = var.availability_zones_and_private_subnet_cidrs
+
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-private-rt-${each.key}"
+    AZ   = each.key
+  })
+}
+
+# Routes for Private Subnets to NAT Gateways
+resource "aws_route" "private_nat" {
+  for_each = var.availability_zones_and_private_subnet_cidrs
+
+  route_table_id         = aws_route_table.private[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.main[each.key].id
+}
+
+# Route Table Associations for Private Subnets
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private[each.key].id
+}

--- a/modules/network/vpc/security-group.tf
+++ b/modules/network/vpc/security-group.tf
@@ -1,0 +1,31 @@
+# Security Group for VPC Endpoints
+resource "aws_security_group" "vpc_endpoints" {
+  count = var.enable_vpc_endpoints ? 1 : 0
+
+  name_prefix = "${var.environment}-${var.app_name}-vpc-endpoints-"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTPS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-vpc-endpoints-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/network/vpc/subnets.tf
+++ b/modules/network/vpc/subnets.tf
@@ -1,0 +1,30 @@
+# Public Subnets
+resource "aws_subnet" "public" {
+  for_each = var.availability_zones_and_public_subnet_cidrs
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = each.value
+  availability_zone       = "${data.aws_region.current.name}${each.key}"
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-public-subnet-${each.key}"
+    Type = "Public"
+    AZ   = each.key
+  })
+}
+
+# Private Subnets
+resource "aws_subnet" "private" {
+  for_each = var.availability_zones_and_private_subnet_cidrs
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = each.value
+  availability_zone = "${data.aws_region.current.name}${each.key}"
+
+  tags = merge(var.tags, {
+    Name = "${var.environment}-${var.app_name}-private-subnet-${each.key}"
+    Type = "Private"
+    AZ   = each.key
+  })
+}

--- a/modules/network/vpc/variables.tf
+++ b/modules/network/vpc/variables.tf
@@ -1,0 +1,103 @@
+variable "environment" {
+  description = "Environment name (e.g., dev, prod)"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "VPC CIDR must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "availability_zones_and_public_subnet_cidrs" {
+  description = "Map of availability zones to public subnet CIDR blocks"
+  type        = map(string)
+  validation {
+    condition     = length(var.availability_zones_and_public_subnet_cidrs) >= 2
+    error_message = "At least 2 public subnets are required for high availability."
+  }
+}
+
+variable "availability_zones_and_private_subnet_cidrs" {
+  description = "Map of availability zones to private subnet CIDR blocks"
+  type        = map(string)
+  validation {
+    condition     = length(var.availability_zones_and_private_subnet_cidrs) >= 2
+    error_message = "At least 2 private subnets are required for high availability."
+  }
+}
+
+variable "enable_nat_gateway" {
+  description = "Should be true to provision NAT Gateways for each of your private networks"
+  type        = bool
+  default     = true
+}
+
+variable "enable_vpn_gateway" {
+  description = "Should be true to provision a VPN Gateway"
+  type        = bool
+  default     = false
+}
+
+variable "enable_dns_hostnames" {
+  description = "Should be true to enable DNS hostnames in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_support" {
+  description = "Should be true to enable DNS support in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_flow_logs" {
+  description = "Should be true to enable VPC Flow Logs"
+  type        = bool
+  default     = true
+}
+
+variable "flow_log_retention_days" {
+  description = "Retention period for VPC Flow Logs in CloudWatch"
+  type        = number
+  default     = 14
+  validation {
+    condition = contains([
+      1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653
+    ], var.flow_log_retention_days)
+    error_message = "Flow log retention days must be a valid CloudWatch log retention period."
+  }
+}
+
+variable "enable_vpc_endpoints" {
+  description = "Should be true to enable VPC endpoints for AWS services"
+  type        = bool
+  default     = false
+}
+
+variable "single_nat_gateway" {
+  description = "Should be true to provision a single shared NAT Gateway across all private networks"
+  type        = bool
+  default     = false
+}
+
+variable "one_nat_gateway_per_az" {
+  description = "Should be true to provision only one NAT Gateway per availability zone"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resource"
+  type        = map(string)
+  default     = {}
+}
+


### PR DESCRIPTION
## 概要
以下のVPC関連のモジュールを追加

- VPC
- サブネット (public *2, private *2)
- ルーティング
- NATゲートウェイ
- VPCゲートウェイ (S3 Gatewayは必須、その他のゲートウェイはvariableで必須/非必須を設定可能)
- VPCフローログ
- セキュリティグループ